### PR TITLE
Functionaliteit toegevoegd om i, l en 1 te excluden. En om alleen een hashtag te gebruiken.

### DIFF
--- a/src/routes/homecomponents/PasswordCard.svelte
+++ b/src/routes/homecomponents/PasswordCard.svelte
@@ -71,7 +71,7 @@
 		includeNumbers: boolean,
 		excludeIl1: boolean,
 		includeSymbols: boolean,
-		includeSymbols2: boolean
+		includeHashtag: boolean
 	) {
 		let charCodes = LOWERCASE_CHAR_CODES;
 		if (includeUppercase === true) charCodes = charCodes.concat(UPPERCASE_CHAR_CODES);
@@ -102,7 +102,7 @@
 			NewPassword = passwordArray.join('');
 		}
 
-		if(!includeSymbols && includeSymbols2) {
+		if(!includeSymbols && includeHashtag) {
 			let randomIndex = Math.floor(Math.random() * characterAmount);
 			let passwordArray = NewPassword.split('');
 			passwordArray[randomIndex] = '#';
@@ -119,12 +119,12 @@
 		Numbers: boolean,
 		Excludeil1: boolean,
 		Symbols: boolean,
-		Symbols2: boolean
+		Hashtag: boolean
 	) {
 		for (let i = 0; i < amount; i++) {
 			ListOfPasswords = [
 				...ListOfPasswords,
-				generatePassword(PasswordLength, UpperCase, Numbers, Excludeil1, Symbols, Symbols2)
+				generatePassword(PasswordLength, UpperCase, Numbers, Excludeil1, Symbols, Hashtag)
 			];
 		}
 	}
@@ -274,14 +274,14 @@
 			>
 				Symbols
 			</Label><Checkbox
-				id="Symbols2"
+				id="Hashtag"
 				bind:checked={Hashtag}
 				on:click={HandleChangeOptions}
-				aria-labelledby="Symbols2-label"
+				aria-labelledby="Hashtag-label"
 			/>
 			<Label
-				id="Symbols2-label"
-				for="Symbols2"
+				id="Hashtag-label"
+				for="Hashtag"
 				class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 			>
 				Hashtag

--- a/src/routes/homecomponents/PasswordCard.svelte
+++ b/src/routes/homecomponents/PasswordCard.svelte
@@ -13,20 +13,20 @@
 
 	$: UpperCase = true;
 	$: Numbers = true;
-	$: Excludeil1 = true;
+	$: ExcludeSimilar = true;
 	$: Symbols = false;
-	$: Hashtag = true;
+	$: SimpleSymbols = true;
 	$: AmountPasswords = 5;
 	$: PasswordLength = 14;
 
 	let ListOfPasswords: string[] = [];
 
 	onMount(() => {
-		generatePasswords(5, PasswordLength, UpperCase, Numbers, Excludeil1, Symbols, Hashtag);
+		generatePasswords(5, PasswordLength, UpperCase, Numbers, ExcludeSimilar, Symbols, SimpleSymbols);
 	});
 
 	function HandleGeneratePasswords() {
-		generatePasswords(AmountPasswords, PasswordLength, UpperCase, Numbers, Excludeil1, Symbols, Hashtag);
+		generatePasswords(AmountPasswords, PasswordLength, UpperCase, Numbers, ExcludeSimilar, Symbols, SimpleSymbols);
 	}
 
 	function HandleReset() {
@@ -37,7 +37,7 @@
 		let currentPasswords = ListOfPasswords.length;
 		ListOfPasswords = [];
 		await new Promise(f => setTimeout(f, 1000));
-		generatePasswords(currentPasswords, PasswordLength, UpperCase, Numbers, Excludeil1, Symbols, Hashtag);
+		generatePasswords(currentPasswords, PasswordLength, UpperCase, Numbers, ExcludeSimilar, Symbols, SimpleSymbols);
 	}
 	// Password Scripts
 	function arrayFromLowToHigh(low: number, high: number) {
@@ -64,20 +64,21 @@
 		.concat(arrayFromLowToHigh(35, 36))
 		.concat(arrayFromLowToHigh(38, 38))
 		.concat(arrayFromLowToHigh(42, 42));
+	const SIMPLE_SYMBOLS_CHAR_CODES = ['!', '@', '#', '$'];
 
 	function generatePassword(
 		characterAmount: number,
 		includeUppercase: boolean,
 		includeNumbers: boolean,
-		excludeIl1: boolean,
+		ExcludeSimilar: boolean,
 		includeSymbols: boolean,
-		includeHashtag: boolean
+		includeSimpleSymbols: boolean
 	) {
 		let charCodes = LOWERCASE_CHAR_CODES;
 		if (includeUppercase === true) charCodes = charCodes.concat(UPPERCASE_CHAR_CODES);
 		if (includeNumbers === true) charCodes = charCodes.concat(NUMBER_CHAR_CODES);
 		if (includeSymbols === true) charCodes = charCodes.concat(SYMBOL_CHAR_CODES);
-		if(excludeIl1) removeItemsFromArray(charCodes, [49, 73, 105, 108]);
+		if(ExcludeSimilar) removeItemsFromArray(charCodes, [48, 49, 73, 79, 105, 108, 111]);
 
 		const passwordCharacters = [];
 
@@ -102,10 +103,10 @@
 			NewPassword = passwordArray.join('');
 		}
 
-		if(!includeSymbols && includeHashtag) {
+		if(!includeSymbols && includeSimpleSymbols) {
 			let randomIndex = Math.floor(Math.random() * characterAmount);
 			let passwordArray = NewPassword.split('');
-			passwordArray[randomIndex] = '#';
+			passwordArray[randomIndex] = SIMPLE_SYMBOLS_CHAR_CODES[Math.floor(Math.random() * SIMPLE_SYMBOLS_CHAR_CODES.length)];
 			NewPassword = passwordArray.join('');
 		}
 
@@ -117,14 +118,14 @@
 		PasswordLength: number,
 		UpperCase: boolean,
 		Numbers: boolean,
-		Excludeil1: boolean,
+		ExcludeSimilar: boolean,
 		Symbols: boolean,
-		Hashtag: boolean
+		SimpleSymbols: boolean
 	) {
 		for (let i = 0; i < amount; i++) {
 			ListOfPasswords = [
 				...ListOfPasswords,
-				generatePassword(PasswordLength, UpperCase, Numbers, Excludeil1, Symbols, Hashtag)
+				generatePassword(PasswordLength, UpperCase, Numbers, ExcludeSimilar, Symbols, SimpleSymbols)
 			];
 		}
 	}
@@ -247,20 +248,33 @@
 				Numbers
 			</Label>
 			<Checkbox
-				id="Excludeil1"
-				bind:checked={Excludeil1}
+				id="ExcludeSimilar"
+				bind:checked={ExcludeSimilar}
 				on:click={HandleChangeOptions}
-				aria-labelledby="Excludeil1-label"
+				aria-labelledby="ExcludeSimilar-label"
 			/>
 			<Label
-				id="Excludeil1-label"
-				for="Excludeil1"
+				id="ExcludeSimilar-label"
+				for="ExcludeSimilar"
 				class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 			>
-				Exclude i-l-1
+				Exclude Similar
 			</Label>
 		</div>
 		<div class="mt-2 flex space-x-2">
+			<Checkbox
+				id="SimpleSymbols"
+				bind:checked={SimpleSymbols}
+				on:click={HandleChangeOptions}
+				aria-labelledby="SimpleSymbols-label"
+			/>
+			<Label
+				id="SimpleSymbols-label"
+				for="SimpleSymbols"
+				class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+			>
+				Simple Symbols
+			</Label>
 			<Checkbox
 				id="Symbols"
 				bind:checked={Symbols}
@@ -273,18 +287,6 @@
 				class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 			>
 				Symbols
-			</Label><Checkbox
-				id="Hashtag"
-				bind:checked={Hashtag}
-				on:click={HandleChangeOptions}
-				aria-labelledby="Hashtag-label"
-			/>
-			<Label
-				id="Hashtag-label"
-				for="Hashtag"
-				class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-			>
-				Hashtag
 			</Label>
 		</div>
 		<div class="mt-2 flex space-x-2">

--- a/src/routes/homecomponents/PasswordCard.svelte
+++ b/src/routes/homecomponents/PasswordCard.svelte
@@ -13,19 +13,20 @@
 
 	$: UpperCase = true;
 	$: Numbers = true;
-	$: Symbols = true;
-	$: Symbols2 = false;
+	$: Excludeil1 = true;
+	$: Symbols = false;
+	$: Hashtag = true;
 	$: AmountPasswords = 5;
 	$: PasswordLength = 14;
 
 	let ListOfPasswords: string[] = [];
 
 	onMount(() => {
-		generatePasswords(5, PasswordLength, UpperCase, Numbers, Symbols, Symbols2);
+		generatePasswords(5, PasswordLength, UpperCase, Numbers, Excludeil1, Symbols, Hashtag);
 	});
 
 	function HandleGeneratePasswords() {
-		generatePasswords(AmountPasswords, PasswordLength, UpperCase, Numbers, Symbols, Symbols2);
+		generatePasswords(AmountPasswords, PasswordLength, UpperCase, Numbers, Excludeil1, Symbols, Hashtag);
 	}
 
 	function HandleReset() {
@@ -36,7 +37,7 @@
 		let currentPasswords = ListOfPasswords.length;
 		ListOfPasswords = [];
 		await new Promise(f => setTimeout(f, 1000));
-		generatePasswords(currentPasswords, PasswordLength, UpperCase, Numbers, Symbols, Symbols2);
+		generatePasswords(currentPasswords, PasswordLength, UpperCase, Numbers, Excludeil1, Symbols, Hashtag);
 	}
 	// Password Scripts
 	function arrayFromLowToHigh(low: number, high: number) {
@@ -47,6 +48,15 @@
 		return array;
 	}
 
+	function removeItemsFromArray(array: any[], value: any[]) {
+		for(let i = 0; i < value.length; i++) {
+			let index = array.indexOf(value[i]);
+
+			if(index != -1)
+				array.splice(index, 1);
+		}
+	}
+
 	const UPPERCASE_CHAR_CODES = arrayFromLowToHigh(65, 90);
 	const LOWERCASE_CHAR_CODES = arrayFromLowToHigh(97, 122);
 	const NUMBER_CHAR_CODES = arrayFromLowToHigh(48, 57);
@@ -54,14 +64,12 @@
 		.concat(arrayFromLowToHigh(35, 36))
 		.concat(arrayFromLowToHigh(38, 38))
 		.concat(arrayFromLowToHigh(42, 42));
-	const SYMBOL2_CHAR_CODES = arrayFromLowToHigh(58, 64)
-		.concat(arrayFromLowToHigh(91, 96))
-		.concat(arrayFromLowToHigh(123, 126));
 
 	function generatePassword(
 		characterAmount: number,
 		includeUppercase: boolean,
 		includeNumbers: boolean,
+		excludeIl1: boolean,
 		includeSymbols: boolean,
 		includeSymbols2: boolean
 	) {
@@ -69,7 +77,7 @@
 		if (includeUppercase === true) charCodes = charCodes.concat(UPPERCASE_CHAR_CODES);
 		if (includeNumbers === true) charCodes = charCodes.concat(NUMBER_CHAR_CODES);
 		if (includeSymbols === true) charCodes = charCodes.concat(SYMBOL_CHAR_CODES);
-		if (includeSymbols2 === true) charCodes = charCodes.concat(SYMBOL2_CHAR_CODES);
+		if(excludeIl1) removeItemsFromArray(charCodes, [49, 73, 105, 108]);
 
 		const passwordCharacters = [];
 
@@ -94,6 +102,13 @@
 			NewPassword = passwordArray.join('');
 		}
 
+		if(!includeSymbols && includeSymbols2) {
+			let randomIndex = Math.floor(Math.random() * characterAmount);
+			let passwordArray = NewPassword.split('');
+			passwordArray[randomIndex] = '#';
+			NewPassword = passwordArray.join('');
+		}
+
 		return NewPassword;
 	}
 
@@ -102,13 +117,14 @@
 		PasswordLength: number,
 		UpperCase: boolean,
 		Numbers: boolean,
+		Excludeil1: boolean,
 		Symbols: boolean,
 		Symbols2: boolean
 	) {
 		for (let i = 0; i < amount; i++) {
 			ListOfPasswords = [
 				...ListOfPasswords,
-				generatePassword(PasswordLength, UpperCase, Numbers, Symbols, Symbols2)
+				generatePassword(PasswordLength, UpperCase, Numbers, Excludeil1, Symbols, Symbols2)
 			];
 		}
 	}
@@ -230,6 +246,19 @@
 			>
 				Numbers
 			</Label>
+			<Checkbox
+				id="Excludeil1"
+				bind:checked={Excludeil1}
+				on:click={HandleChangeOptions}
+				aria-labelledby="Excludeil1-label"
+			/>
+			<Label
+				id="Excludeil1-label"
+				for="Excludeil1"
+				class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+			>
+				Exclude i-l-1
+			</Label>
 		</div>
 		<div class="mt-2 flex space-x-2">
 			<Checkbox
@@ -246,7 +275,7 @@
 				Symbols
 			</Label><Checkbox
 				id="Symbols2"
-				bind:checked={Symbols2}
+				bind:checked={Hashtag}
 				on:click={HandleChangeOptions}
 				aria-labelledby="Symbols2-label"
 			/>
@@ -255,7 +284,7 @@
 				for="Symbols2"
 				class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 			>
-				Symbols2
+				Hashtag
 			</Label>
 		</div>
 		<div class="mt-2 flex space-x-2">


### PR DESCRIPTION
Ik heb een knop "Exclude i, l & 1" toegevoegd (die standaard aan staat)
Knop "Symbols 2" heb ik aangepast naar "Hashtag" (standaard aan i.p.v. Symbols)

Nu wordt er een wachtwoord gemaakt met letters, cijfers en gegarandeerd 1 hashtag.
Als je nog andere ideeën hebt, of ik nog iets moet aan passen kun je deze pull request gewoon annuleren.